### PR TITLE
Add LFS support to the checkout action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown


### PR DESCRIPTION
This ensures the actual jars get into the deployed artifacts. Long-term this should get removed for a more robust workflow that pulls in these artifacts (maybe even at multiple versions) only at deployment time.