### PR TITLE
Lift code input into its own component

### DIFF
--- a/index.scss
+++ b/index.scss
@@ -8,28 +8,20 @@ body {
   align-items: center;
   display: flex;
   justify-content: center;
-
-  background: linear-gradient(to bottom right, #444444, #009a5b);
   font-size: 1.5rem;
 }
 
 main {
-  color: #fff6d5;
   font-family: sans-serif;
   text-align: center;
 }
 
-.logo {
-  height: 20em;
-}
-
-.heart:after {
-  content: "❤️";
-
-  font-size: 1.75em;
-}
-
-h1 + .subtitle {
+h1+.subtitle {
   display: block;
   margin-top: -1em;
+}
+
+textarea,
+.monospaced {
+  font-family: Consolas, Monaco, Lucida Console, Courier New, monospace;
 }

--- a/src/code_input.rs
+++ b/src/code_input.rs
@@ -1,0 +1,47 @@
+use log::error;
+use wasm_bindgen::JsCast;
+use web_sys::{HtmlInputElement, HtmlTextAreaElement};
+use yew::{function_component, html, Callback, Html, MouseEvent, Properties, TargetCast};
+
+const INPUT_ID: &str = "code-input-content";
+
+#[derive(Properties, PartialEq)]
+pub struct CodeInputProps {
+    pub on_submit: Callback<String>,
+}
+
+#[function_component]
+pub fn CodeInput(props: &CodeInputProps) -> Html {
+    let onclick = &props.on_submit.reform(|event: MouseEvent| {
+        let input: HtmlInputElement = event.target_unchecked_into();
+        let code = input
+            .owner_document()
+            .and_then(|document| document.get_element_by_id(INPUT_ID))
+            .and_then(|element| {
+                element
+                    .dyn_into::<HtmlTextAreaElement>()
+                    .map(|text_input| text_input.value())
+                    .ok()
+            });
+
+        if code.is_none() {
+            error!("Failed to get input from {INPUT_ID} in the DOM");
+        }
+
+        code.unwrap_or_default()
+    });
+
+    html! {
+        <div>
+            <textarea id={INPUT_ID}
+                rows=20
+                cols=80
+                autocapitalize="off"
+                autocomplete="off"
+                autocorrect="off"
+                spellcheck="false"/>
+            <br/>
+            <button {onclick}>{ "Evaluate" }</button>
+        </div>
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod code_input;
 mod fusion_runtime;
 mod fusion_sandbox;
 


### PR DESCRIPTION
This helps separate the concerns of the styling and management of the input content itself from the invocation and execution lifecycle. The output should eventually be similarly lifted out.